### PR TITLE
Refactor Core.Patch API ergonomics and add README

### DIFF
--- a/GersangStation.WinUI/Core/Core.Test/PatchPlanBuilderTest.cs
+++ b/GersangStation.WinUI/Core/Core.Test/PatchPlanBuilderTest.cs
@@ -14,7 +14,7 @@ public sealed class PatchPlanBuilderTest
             [34001] = [MakeRow("_patchdata_34001.gsz", row4: "ignored", row6: "3993170318", "")]
         };
 
-        var plan = PatchPlanBuilder_StringRows.BuildExtractPlan(entriesByVersion);
+        var plan = PatchPlanBuilder.BuildExtractPlan(entriesByVersion);
 
         Assert.AreEqual(1, plan.ByVersion.Count);
         var file = plan.ByVersion[34001].Single();
@@ -30,4 +30,29 @@ public sealed class PatchPlanBuilderTest
             return row;
         }
     }
+
+    [TestMethod]
+    public void LegacyPatchPlanBuilderStringRows_DelegatesToNewBuilder()
+    {
+        IReadOnlyDictionary<int, List<string[]>> entriesByVersion = new Dictionary<int, List<string[]>>
+        {
+            [34001] = [MakeRow("_patchdata_34001.gsz", row4: "ignored", row6: "3993170318", "\\Online\\")]
+        };
+
+        var plan = PatchPlanBuilder_StringRows.BuildExtractPlan(entriesByVersion);
+
+        Assert.AreEqual(1, plan.ByVersion.Count);
+        Assert.AreEqual("_patchdata_34001.gsz", plan.ByVersion[34001].Single().CompressedFileName);
+
+        static string[] MakeRow(string compressedFileName, string row4, string row6, string relativeDir)
+        {
+            var row = new string[7];
+            row[1] = compressedFileName;
+            row[3] = relativeDir;
+            row[4] = row4;
+            row[6] = row6;
+            return row;
+        }
+    }
+
 }

--- a/GersangStation.WinUI/Core/Patch/DownloadManager.cs
+++ b/GersangStation.WinUI/Core/Patch/DownloadManager.cs
@@ -85,6 +85,9 @@ public sealed class DownloadManager : IAsyncDisposable
         return tcs.Task;
     }
 
+    /// <summary>
+    /// 간편 오버로드: 취소 제어가 필요 없을 때 사용합니다.
+    /// </summary>
     public Task EnqueueAsync(
         Uri url,
         string destinationPath,

--- a/GersangStation.WinUI/Core/Patch/PatchPipeline.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchPipeline.cs
@@ -7,6 +7,30 @@ namespace Core.Patch;
 public static class PatchPipeline
 {
     /// <summary>
+    /// <see cref="CancellationToken"/>을 모르는 호출자를 위한 간편 오버로드입니다.
+    /// 내부적으로 <see cref="CancellationToken.None"/>을 사용합니다.
+    /// </summary>
+    public static Task RunPatchFromServerAsync(
+        int currentClientVersion,
+        Uri patchBaseUri,
+        string installRoot,
+        string tempRoot,
+        int maxConcurrency,
+        int maxExtractRetryCount,
+        bool cleanupTemp = true)
+    {
+        return RunPatchFromServerAsync(
+            currentClientVersion,
+            patchBaseUri,
+            installRoot,
+            tempRoot,
+            maxConcurrency,
+            maxExtractRetryCount,
+            CancellationToken.None,
+            cleanupTemp);
+    }
+
+    /// <summary>
     /// 서버 메타(vsn.dat.gsz + Client_info_File/{version})를 읽어
     /// 다운로드/병합/압축해제 파이프라인을 실행한다.
     /// </summary>
@@ -32,7 +56,34 @@ public static class PatchPipeline
     }
 
     /// <summary>
+    /// <see cref="CancellationToken"/>을 모르는 호출자를 위한 간편 오버로드입니다.
+    /// 내부적으로 <see cref="CancellationToken.None"/>을 사용합니다.
+    /// </summary>
+    public static Task RunPatchAsync(
+        int currentClientVersion,
+        Uri patchBaseUri,
+        string installRoot,
+        string tempRoot,
+        int maxConcurrency,
+        int maxExtractRetryCount,
+        bool cleanupTemp = true)
+    {
+        return RunPatchAsync(
+            currentClientVersion,
+            patchBaseUri,
+            installRoot,
+            tempRoot,
+            maxConcurrency,
+            maxExtractRetryCount,
+            CancellationToken.None,
+            cleanupTemp);
+    }
+
+    /// <summary>
     /// 패치 파일 다운로드 + (버전 오름차순) 압축 해제 + 임시폴더 정리.
+    ///
+    /// <para>CancellationToken은 "중간에 멈추고 싶을 때" 전달하는 취소 신호입니다.</para>
+    /// <para>취소를 쓰지 않으면 간편 오버로드(토큰 없는 메서드)를 사용해도 됩니다.</para>
     ///
     /// 1) vsn.dat.gsz로 최신 버전 조회
     /// 2) 현재+1..최신 버전의 Client_info_File 수집
@@ -78,7 +129,7 @@ public static class PatchPipeline
             // -----------------------------------------------------------------
             // 3) 최신 우선 병합 + 5) 버전 오름차순 해제용 ExtractPlan 생성
             // -----------------------------------------------------------------
-            var plan = PatchPlanBuilder_StringRows.BuildExtractPlan(entriesByVersion);
+            var plan = PatchPlanBuilder.BuildExtractPlan(entriesByVersion);
 
             ct.ThrowIfCancellationRequested();
 

--- a/GersangStation.WinUI/Core/Patch/PatchPlanBuilder.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchPlanBuilder.cs
@@ -1,6 +1,9 @@
 ﻿namespace Core.Patch;
 
-public static class PatchPlanBuilder_StringRows
+/// <summary>
+/// Client_info_File의 문자열 행(탭 분리 컬럼)을 <see cref="PatchExtractPlan"/>으로 변환합니다.
+/// </summary>
+public static class PatchPlanBuilder
 {
     /// <summary>
     /// entriesByVersion[v]는 "row 배열" 리스트. (탭 split 결과)
@@ -60,4 +63,15 @@ public static class PatchPlanBuilder_StringRows
 
         return plan;
     }
+}
+
+/// <summary>
+/// 기존 호출 코드 호환용 타입.
+/// 신규 코드는 <see cref="PatchPlanBuilder"/>를 사용하세요.
+/// </summary>
+public static class PatchPlanBuilder_StringRows
+{
+    public static PatchExtractPlan BuildExtractPlan(
+        IReadOnlyDictionary<int, List<string[]>> entriesByVersion)
+        => PatchPlanBuilder.BuildExtractPlan(entriesByVersion);
 }

--- a/GersangStation.WinUI/Core/Patch/README.md
+++ b/GersangStation.WinUI/Core/Patch/README.md
@@ -1,0 +1,129 @@
+# Core.Patch API 가이드
+
+이 문서는 `Core.Patch` 라이브러리를 **처음 쓰는 WinUI 프론트 개발자**와, 내부 동작까지 알아야 하는 개발자를 모두 대상으로 작성했습니다.
+
+---
+
+## 1) 빠른 사용법 (프론트 개발자용)
+
+"패치하고 싶다"면, 아래 메서드 하나만 호출하면 됩니다.
+
+```csharp
+await PatchPipeline.RunPatchAsync(
+    currentClientVersion: currentVersion,
+    patchBaseUri: new Uri("https://akgersang.xdn.kinxcdn.com/Gersang/Patch/Gersang_Server/"),
+    installRoot: gameInstallPath,
+    tempRoot: tempPatchPath,
+    maxConcurrency: 2,
+    maxExtractRetryCount: 2,
+    cleanupTemp: true);
+```
+
+### 인자 설명 (쉽게)
+- `currentClientVersion`: 현재 설치된 클라이언트 버전
+- `patchBaseUri`: 패치 서버 루트 URL
+- `installRoot`: 실제 게임 파일이 깔린 폴더
+- `tempRoot`: 다운로드 중간 파일(.gsz) 임시 보관 폴더
+- `maxConcurrency`: 동시 다운로드 개수 (보통 2 추천)
+- `maxExtractRetryCount`: 압축 해제 실패 시 재시도 횟수
+- `cleanupTemp`: 끝난 뒤 임시 폴더 삭제 여부
+
+### CancellationToken(취소 토큰) 꼭 알아야 하나요?
+아니요. 몰라도 됩니다.
+
+- `RunPatchAsync(...)` / `RunPatchFromServerAsync(...)`에는 **토큰 없는 오버로드**가 있습니다.
+- 그냥 위 예시처럼 호출하면 내부적으로 `CancellationToken.None`이 들어갑니다.
+- "취소 버튼" 같은 기능이 필요할 때만 토큰 버전을 쓰면 됩니다.
+
+---
+
+## 2) 상세 문서 (개발자용)
+
+## 주요 공개 타입
+
+### `PatchPipeline`
+패치 전체 오케스트레이션 엔트리입니다.
+
+- `RunPatchAsync(...)`
+  - 서버 메타(`vsn.dat.gsz`, `Client_info_File/{version}`)를 읽고
+  - 다운로드 계획을 만들고
+  - 필요한 `.gsz`를 병렬 다운로드 후
+  - 버전 오름차순으로 압축 해제합니다.
+- `RunPatchFromServerAsync(...)`
+  - 현재는 `RunPatchAsync`의 의미상 별칭입니다.
+- `DecodeLatestVersionFromVsnDat(ReadOnlySpan<byte>/Stream)`
+  - `vsn.dat` 바이너리에서 최신 버전을 디코딩합니다.
+- `ParseClientInfoRows(string)`
+  - `Client_info_File` 텍스트를 탭 컬럼 배열(`string[]`) 리스트로 파싱합니다.
+
+### `PatchPlanBuilder`
+`Client_info_File` 행들을 `PatchExtractPlan`으로 바꿉니다.
+
+- 중복 키는 `relativeDir + compressedFileName`
+- 최신 버전 행이 우선
+- 결과는 `SourceVersion` 기준 그룹
+
+#### 레거시 호환
+- `PatchPlanBuilder_StringRows`는 호환용 래퍼입니다.
+- 신규 코드는 `PatchPlanBuilder` 사용을 권장합니다.
+
+### `PatchExtractPlan` / `PatchFile`
+다운로드/압축해제 대상 스냅샷 모델입니다.
+
+- `PatchExtractPlan.ByVersion`: `SortedDictionary<int, List<PatchFile>>`
+- 키(버전) 오름차순 순회 시, 안전한 적용 순서를 그대로 사용할 수 있습니다.
+
+### `PatchDownloaderStage`
+계획에 포함된 `.gsz`를 `tempRoot/{version}/` 하위로 다운로드합니다.
+
+- 내부적으로 `Downloader + DownloadManager`를 사용
+- 취소(`OperationCanceledException`) 발생 시 임시폴더 삭제(best-effort)
+
+### `Downloader`
+단일 파일 다운로드 담당.
+
+- Range + If-Range 기반 resume 지원
+- 서버가 200 전체 응답으로 되돌아오면 partial 폐기 후 재시작
+- 재시도 + 백오프 내장
+
+### `DownloadManager`
+여러 다운로드를 큐잉/중복제거/동시성 제어합니다.
+
+- `EnqueueAsync(url, path, options, progress, ct)`
+- `EnqueueAsync(url, path, options, progress = null)` 간편 오버로드
+- 키(`url||destinationPath`) 기준 중복 작업은 기존 Task를 반환
+
+### `ZipCrcReader`
+ZIP/GSZ Central Directory에서 엔트리 CRC를 읽는 유틸입니다.
+
+- `ReadEntryCrcMap`
+- `IsSupportedZipLikeFile`
+- CRC 10진/16진 변환 보조 메서드
+
+---
+
+## 호출 패턴 예시 (취소 지원 버전)
+
+```csharp
+using var cts = new CancellationTokenSource();
+
+// 예: 취소 버튼 클릭 시 cts.Cancel();
+await PatchPipeline.RunPatchAsync(
+    currentClientVersion: currentVersion,
+    patchBaseUri: patchBaseUri,
+    installRoot: installRoot,
+    tempRoot: tempRoot,
+    maxConcurrency: 2,
+    maxExtractRetryCount: 2,
+    ct: cts.Token,
+    cleanupTemp: true);
+```
+
+---
+
+## 동작/정책 요약
+
+- 패치 적용은 **버전 오름차순**
+- 같은 파일 경로 충돌 시 **최신 버전 메타 우선**
+- 취소/실패 시 임시 데이터 정리(best-effort)
+- 압축 해제 시 zip-slip 방어(루트 경로 이탈 차단)


### PR DESCRIPTION
### Motivation
- Make `Core.Patch` easier to consume for front-end developers by providing simpler entry points and clearer names.
- Preserve backward compatibility for existing callers while steering new code to a clearer API surface.
- Provide a short, friendly README for non-core developers (WinUI front) plus a developer-facing detailed reference.

### Description
- Introduced `PatchPlanBuilder` as the primary builder for converting `Client_info_File` rows to `PatchExtractPlan` and retained `PatchPlanBuilder_StringRows` as a compatibility wrapper that delegates to the new type.
- Updated `PatchPipeline` to use `PatchPlanBuilder` and added token-less convenience overloads `RunPatchAsync(...)` and `RunPatchFromServerAsync(...)` that call the existing token-based implementations with `CancellationToken.None`, plus XML docs explaining cancellation intent.
- Added explanatory XML comments and a short clarifying comment on the `DownloadManager.EnqueueAsync` token-less overload to make intent obvious to callers. 
- Added `GersangStation.WinUI/Core/Patch/README.md` containing two parts: a beginner-friendly quick-call guide and a developer-focused API/behavior reference, and updated `Core.Test/PatchPlanBuilderTest.cs` to assert new API usage and compatibility.

### Testing
- Attempted to run the targeted unit tests (`PatchPlanBuilderTest`) with `dotnet test`, but the environment lacks the `dotnet` CLI so the test run failed with `bash: command not found: dotnet`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d08c3549483219ba868c57b3ac862)