### PR TITLE
Refine full-client install archive reuse flow

### DIFF
--- a/GersangStation.WinUI/Core/Patch/README.md
+++ b/GersangStation.WinUI/Core/Patch/README.md
@@ -32,7 +32,7 @@ string readMeText = await PatchClientApi.DownloadReadMeAsync();
 - `GetLatestServerVersionAsync()`
 - `PatchAsync(currentClientVersion)`
 - `DownloadReadMeAsync()`
-- `InstallFullClientAsync(installRoot, tempRoot)`
+- `InstallFullClientAsync(installRoot, ..., skipDownloadIfArchiveExists)`
 
 ### 최소 호출 흐름
 


### PR DESCRIPTION
### Motivation
- Ensure the installer uses a deterministic archive path under the final install folder (`<installRoot>/Gersang_Install.7z`) and asks the user whether to reuse an existing archive instead of relying on exception-string matching. 
- Make the download intent explicit at the API boundary so callers can express the desired download/overwrite policy without passing a temporary folder.
- Remove fragile exception-message-based logic and replace it with a clear pre-check + branch for skipping or performing the download.

### Description
- Updated `SetupGameStepPage.OnInstallButtonClicked` to compute `archivePath = Path.Combine(installRootWithGameFolder, "Gersang_Install.7z")` and show a `ContentDialog` when the file already exists with Title `이미 게임 압축파일이 존재합니다. 다시 다운로드 하시겠습니까?` and buttons `예` (re-download) / `건너뛰기` (use existing). The dialog result is converted to `skipDownloadIfArchiveExists` (`건너뛰기` => `true`, `예` => `false`).
- Changed callsite to pass `skipDownloadIfArchiveExists` into `PatchClientApi.InstallFullClientAsync` and updated local variables to use `installRootWithGameFolder` for clarity.
- Refactored `PatchClientApi.InstallFullClientAsync` to remove the `tempRoot` parameter, compute `archivePath` under `installRoot`, and deterministically branch: if `archiveExists && skipDownloadIfArchiveExists` then skip download, otherwise call downloader with `DownloadOptions(Overwrite: !skipDownloadIfArchiveExists)`.
- Removed the previous `IOException` string-match guard that depended on `ex.Message.Contains("already exists")` and updated `Core/Patch/README.md` to reflect the new `InstallFullClientAsync(installRoot, ..., skipDownloadIfArchiveExists)` signature.

### Testing
- Attempted an automated build with `dotnet build GersangStation.WinUI/GersangStation/GersangStation.csproj`, but the environment lacks the `dotnet` SDK and the command failed with `command not found` so no full build/test run could be completed.
- Local repository checks (file diffs and commit) were performed and changes committed; no additional automated tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f69bf88cc8321951c4106772d801e)