### PR TITLE
Normalize full-client install root to Gersang folder and update setup flow

### DIFF
--- a/GersangStation.WinUI/Core/Patch/README.md
+++ b/GersangStation.WinUI/Core/Patch/README.md
@@ -32,7 +32,7 @@ string readMeText = await PatchClientApi.DownloadReadMeAsync();
 - `GetLatestServerVersionAsync()`
 - `PatchAsync(currentClientVersion)`
 - `DownloadReadMeAsync()`
-- `InstallFullClientAsync(installRoot, ..., skipDownloadIfArchiveExists)`
+- `InstallFullClientAsync(installRoot, ..., skipDownloadIfArchiveExists) // installRoot 하위 Gersang 폴더를 실제 루트로 사용`
 
 ### 최소 호출 흐름
 

--- a/GersangStation.WinUI/GersangStation/Setup/SetupGameStepPage.xaml.cs
+++ b/GersangStation.WinUI/GersangStation/Setup/SetupGameStepPage.xaml.cs
@@ -346,7 +346,7 @@ public sealed partial class SetupGameStepPage : Page, ISetupStepPage, IBusySetup
                 return;
 
             string installRoot = selectedRoot.Trim();
-            string installRootWithGameFolder = installRoot;
+            string installRootWithGameFolder = PatchClientApi.NormalizeFullClientInstallRoot(installRoot);
             string parentRoot = Directory.GetParent(installRootWithGameFolder)?.FullName ?? installRootWithGameFolder;
             string archivePath = Path.Combine(installRootWithGameFolder, "Gersang_Install.7z");
             bool skipDownloadIfArchiveExists = false;
@@ -408,7 +408,7 @@ public sealed partial class SetupGameStepPage : Page, ISetupStepPage, IBusySetup
             });
 
             await PatchClientApi.InstallFullClientAsync(
-                installRoot: installRootWithGameFolder,
+                installRoot: installRoot,
                 progress: downloadProgress,
                 extractionProgress: extractionProgress,
                 skipDownloadIfArchiveExists: skipDownloadIfArchiveExists,


### PR DESCRIPTION
### Motivation
- Ensure full-client download and extraction always occur under a single, well-known game folder (`...\Gersang`) so later patching/validation paths are consistent. 
- Make the setup UI store the actual game root so saved `InstallPath` matches subsequent patch/verification expectations. 
- Document the new behavior in the `Core/Patch` README for callers of the high-level API.

### Description
- Added `PatchClientApi.NormalizeFullClientInstallRoot(string)` to normalize a requested install root to the actual game folder (returns `...\Gersang` unless the input already ends with `Gersang`).
- Updated `PatchClientApi.InstallFullClientAsync` to use the normalized `actualInstallRoot` for both the download archive path (`Path.Combine(actualInstallRoot, "Gersang_Install.7z")`) and extraction target, and to create the normalized directory before work.
- Updated the setup UI flow in `SetupGameStepPage.xaml.cs` to compute the normalized game folder via `PatchClientApi.NormalizeFullClientInstallRoot(...)`, keep `InstallPath` saved as the normalized game root, and call `InstallFullClientAsync` with the original user-selected root (the API normalizes it internally); removed the prior temporary/duplicate-folder logic in favor of the normalization helper.
- Updated `Core/Patch/README.md` to note the new behavior of `InstallFullClientAsync(installRoot, ...)` where the `installRoot`’s `Gersang` subfolder is used as the real target.

### Testing
- Searched and inspected affected files and callsites with `rg` to verify updates to callers and readme changes, and validated the edited lines in `PatchClientApi.cs` and `SetupGameStepPage.xaml.cs` were consistent; these inspections succeeded.
- Attempted to run an automated build with `dotnet build GersangStation.WinUI/Core/Core.csproj`, but the environment does not have `dotnet` installed, so the build could not be executed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6dd33cc48321bfe7631506651a26)