### PR TITLE
Add ExtractAndReplicateAsync to seven-zip extractor and cleanup archive after install

### DIFF
--- a/GersangStation.WinUI/Core/Extractor/NativeSevenZipExtractor.cs
+++ b/GersangStation.WinUI/Core/Extractor/NativeSevenZipExtractor.cs
@@ -115,6 +115,111 @@ public sealed class NativeSevenZipExtractor : IExtractor
         progress?.Report(new ExtractionProgress(Name, 100, totalEntries ?? 0, totalEntries, null));
     }
 
+    /// <summary>
+    /// 아카이브를 1회만 압축 해제한 뒤, 나머지 대상에는 파일 복제(기본: 복사)로 배포합니다.
+    /// </summary>
+    public async Task ExtractAndReplicateAsync(
+        string archivePath,
+        IReadOnlyList<string> destinationRoots,
+        IProgress<ExtractionProgress>? progress = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(archivePath)) throw new ArgumentException("archivePath is required.", nameof(archivePath));
+        if (destinationRoots is null) throw new ArgumentNullException(nameof(destinationRoots));
+        if (destinationRoots.Count == 0) throw new ArgumentException("At least one destination root is required.", nameof(destinationRoots));
+
+        string primaryRoot = destinationRoots[0];
+        if (string.IsNullOrWhiteSpace(primaryRoot))
+            throw new ArgumentException("Primary destination root is required.", nameof(destinationRoots));
+
+        await ExtractAsync(archivePath, primaryRoot, progress, ct).ConfigureAwait(false);
+
+        if (destinationRoots.Count == 1)
+            return;
+
+        string normalizedPrimaryRoot = Path.GetFullPath(primaryRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        var failedDestinations = new List<string>();
+
+        for (int i = 1; i < destinationRoots.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            string destinationRoot = destinationRoots[i];
+            if (string.IsNullOrWhiteSpace(destinationRoot))
+            {
+                failedDestinations.Add($"(index:{i}) <empty>");
+                continue;
+            }
+
+            string normalizedDestinationRoot = Path.GetFullPath(destinationRoot)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            if (string.Equals(normalizedPrimaryRoot, normalizedDestinationRoot, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                Directory.CreateDirectory(normalizedDestinationRoot);
+                await ReplicateDirectoryAsync(
+                    normalizedPrimaryRoot,
+                    normalizedDestinationRoot,
+                    ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                failedDestinations.Add(normalizedDestinationRoot);
+            }
+        }
+
+        if (failedDestinations.Count > 0)
+            throw new IOException($"Replication failed for {failedDestinations.Count} destination(s): {string.Join(", ", failedDestinations)}");
+    }
+
+    private static async Task ReplicateDirectoryAsync(
+        string sourceRoot,
+        string destinationRoot,
+        CancellationToken ct)
+    {
+        foreach (string sourcePath in Directory.EnumerateFiles(sourceRoot, "*", SearchOption.AllDirectories))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            string relativePath = Path.GetRelativePath(sourceRoot, sourcePath);
+            string destinationPath = Path.Combine(destinationRoot, relativePath);
+
+            string? destinationDir = Path.GetDirectoryName(destinationPath);
+            if (!string.IsNullOrWhiteSpace(destinationDir))
+                Directory.CreateDirectory(destinationDir);
+
+            await CopyFileAsync(sourcePath, destinationPath, ct).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task CopyFileAsync(string sourcePath, string destinationPath, CancellationToken ct)
+    {
+        const int bufferSize = 1024 * 128;
+
+        await using var sourceStream = new FileStream(
+            sourcePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize,
+            useAsync: true);
+
+        await using var destinationStream = new FileStream(
+            destinationPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize,
+            useAsync: true);
+
+        await sourceStream.CopyToAsync(destinationStream, bufferSize, ct).ConfigureAwait(false);
+    }
+
     private async Task<int?> TryGetTotalEntriesAsync(string archivePath, CancellationToken ct)
     {
         var psi = new ProcessStartInfo


### PR DESCRIPTION
### Motivation

- Provide an efficient way to extract an archive once and replicate the extracted files to multiple destination roots to avoid repeated extraction overhead.  
- Ensure the downloaded full-client archive is removed after installation to avoid leaving large temporary files behind.

### Description

- Added `ExtractAndReplicateAsync` to `GersangStation.WinUI/Core/Extractor/NativeSevenZipExtractor.cs` which extracts the archive once to a primary destination and then replicates files to additional destination roots using file-by-file async copying.  
- Implemented `ReplicateDirectoryAsync` and `CopyFileAsync` which copy files using async streams with a 128KB buffer and honor `CancellationToken`, create destination directories as needed, skip identical paths, and accumulate failed destinations to throw an `IOException` if any replication targets fail.  
- Updated `InstallFullClientAsync` in `GersangStation.WinUI/Core/Patch/PatchClientApi.cs` to conditionally skip download when the archive exists and to perform download and extraction inside a `try` block with a `finally` that attempts best-effort deletion of the archive file after the operation.  

### Testing

- Built the solution to verify compile-time correctness and the build succeeded.  
- Executed the existing automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6f0d9cb48321b2d469cbfcfda5b5)