### PR TITLE
Save full client install path to registry after successful extraction

### DIFF
--- a/GersangStation.WinUI/Core/Patch/PatchClientApi.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchClientApi.cs
@@ -1,4 +1,5 @@
 using Core.Extractor;
+using Microsoft.Win32;
 using System.Diagnostics;
 using System.Net;
 
@@ -194,6 +195,7 @@ public static class PatchClientApi
             }
 
             await Extractor.ExtractAsync(archivePath, actualInstallRoot, progress: extractionProgress, ct: ct).ConfigureAwait(false);
+            SaveInstallPathToRegistry(actualInstallRoot);
         }
         finally
         {
@@ -224,5 +226,11 @@ public static class PatchClientApi
         {
             Timeout = timeout
         };
+    }
+
+    private static void SaveInstallPathToRegistry(string installRoot)
+    {
+        using RegistryKey? key = Registry.CurrentUser.CreateSubKey(@"Software\JOYON\Gersang\Korean", writable: true);
+        key?.SetValue("InstallPath", installRoot, RegistryValueKind.String);
     }
 }


### PR DESCRIPTION
### Motivation
- Remember the install location immediately after a successful FullClient download + extraction so the setup UI can read it later. 
- Use the same registry key that `SetupGameStepPage.ReadInstallPathFromRegistry` expects to keep read/write locations consistent.

### Description
- Call `SaveInstallPathToRegistry(actualInstallRoot)` right after successful extraction in `PatchClientApi.InstallFullClientAsync` so the path is persisted when extraction completes. 
- Add a private helper `SaveInstallPathToRegistry(string)` that writes `InstallPath` to `HKCU\Software\JOYON\Gersang\Korean` using `Microsoft.Win32.Registry`. 
- Add `using Microsoft.Win32;` to enable registry operations and persist the normalized `actualInstallRoot` computed by `NormalizeFullClientInstallRoot`.

### Testing
- Attempted to run `dotnet build GersangStation.WinUI/GersangStation.WinUI.slnx -c Release`, but the command failed in this environment with `command not found` because `dotnet` is not installed. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7cc19b6c83218f5905288a824cc0)