### PR TITLE
Add parsing API for latest 5 patch notes from CDN readme

### DIFF
--- a/GersangStation.WinUI/Core/Core.Test/PatchReadMeParseTest.cs
+++ b/GersangStation.WinUI/Core/Core.Test/PatchReadMeParseTest.cs
@@ -1,0 +1,48 @@
+using Core.Patch;
+
+namespace Core.Test;
+
+[TestClass]
+public sealed class PatchReadMeParseTest
+{
+    [TestMethod]
+    public void ParseRecentPatchNotes_ReturnsRecentFivePatchNotes()
+    {
+        string readMe = """
+-2026.02.24-
+[정식 패치 V34020]
+1. 첫 번째 패치 내용입니다.
+- 항목 A
+
+-2026.02.12-
+[정식 패치 V34014]
+1. 두 번째 패치 내용입니다.
+
+-2026.01.28-
+[정식 패치 V34013]
+1. 세 번째 패치 내용입니다.
+
+-2026.01.28-
+[정식 패치 V34012]
+1. 네 번째 패치 내용입니다.
+
+-2026.01.10-
+[정식 패치 V34011]
+1. 다섯 번째 패치 내용입니다.
+
+-2025.12.31-
+[정식 패치 V34010]
+1. 여섯 번째 패치 내용입니다.
+""";
+
+        IReadOnlyList<PatchNote> notes = PatchClientApi.ParseRecentPatchNotes(readMe, takeCount: 5).ToList();
+
+        Assert.AreEqual(5, notes.Count);
+        Assert.AreEqual("2026.02.24", notes[0].DateStr);
+        Assert.AreEqual("[정식 패치 V34020]", notes[0].Title);
+        StringAssert.Contains(notes[0].Note, "첫 번째 패치 내용입니다.");
+
+        Assert.AreEqual("2026.01.10", notes[4].DateStr);
+        Assert.AreEqual("[정식 패치 V34011]", notes[4].Title);
+    }
+}

--- a/GersangStation.WinUI/Core/Patch/PatchNote.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchNote.cs
@@ -1,0 +1,6 @@
+namespace Core.Patch;
+
+public sealed record PatchNote(
+    string DateStr,
+    string Title,
+    string Note);


### PR DESCRIPTION
### Motivation
- Provide a simple API to extract the most recent patch entries (date, title, body) from the server ReadMe (`Client_Readme/readme.txt`) so UI/clients can display recent patch notes. 

### Description
- Add `PatchNote` record with `DateStr`, `Title`, and `Note` fields in `Core.Patch` (`PatchNote.cs`).
- Extend `PatchClientApi` by importing `System.Text.RegularExpressions` and adding a compiled regex to detect date headers in the form `-yyyy.MM.dd-` and a `ParseRecentPatchNotes(string readMeText, int takeCount = 5)` method that returns `IEnumerable<PatchNote>` limited to the newest `takeCount` entries.
- Add `DownloadRecentPatchNotesAsync(int takeCount = 5, CancellationToken ct = default)` which downloads the ReadMe and returns parsed notes in one call.
- Add unit test `PatchReadMeParseTest.ParseRecentPatchNotes_ReturnsRecentFivePatchNotes` to validate the 5-item limit, date mapping, title mapping and that the note body is preserved (`GersangStation.WinUI/Core/Core.Test/PatchReadMeParseTest.cs`).

### Testing
- Added an MSTest unit `PatchReadMeParseTest` to cover parsing behavior, but automated execution via `dotnet test` was attempted and failed in this environment because the `dotnet` CLI is not available (command returned `dotnet: command not found`).
- No automated tests were run successfully in this container; the test was added and is expected to pass in a CI/dev machine with .NET SDK available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f98464cb083218d17cc5b9cfbfccf)