### PR TITLE
PatchAsync 진행도 보고 추가 및 게임 패치 UI 연동

### DIFF
--- a/GersangStation.WinUI/Core/Patch/PatchDownloaderStage.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchDownloaderStage.cs
@@ -14,6 +14,7 @@ public static class PatchDownloaderStage
         string tempRoot,
         GameServer server,                 // 예: https://.../Gersang/Patch/Gersang_Server
         int maxConcurrency,
+        Action<int, int>? onFileDownloaded,
         CancellationToken ct)
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
@@ -37,6 +38,8 @@ public static class PatchDownloaderStage
 
         // enqueue tasks 모아서 await
         var tasks = new List<Task>();
+        int totalFileCount = plan.ByVersion.Values.Sum(files => files.Count);
+        int completedFileCount = 0;
 
         try
         {
@@ -70,7 +73,23 @@ public static class PatchDownloaderStage
                         TempPath: temp,
                         Overwrite: true);
 
-                    tasks.Add(manager.EnqueueAsync(url, dest, options, progress: null, ct));
+                    int completionNotified = 0;
+                    IProgress<DownloadProgress>? progress = onFileDownloaded is null
+                        ? null
+                        : new Progress<DownloadProgress>(p =>
+                        {
+                            long totalBytes = p.TotalBytes ?? 0;
+                            if (totalBytes <= 0 || p.BytesReceived < totalBytes)
+                                return;
+
+                            if (Interlocked.CompareExchange(ref completionNotified, 1, 0) != 0)
+                                return;
+
+                            int completed = Interlocked.Increment(ref completedFileCount);
+                            onFileDownloaded(completed, totalFileCount);
+                        });
+
+                    tasks.Add(manager.EnqueueAsync(url, dest, options, progress: progress, ct));
                 }
             }
 

--- a/GersangStation.WinUI/Core/Patch/PatchHelper.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchHelper.cs
@@ -83,6 +83,19 @@ public static class PatchHelper
     /// </summary>
     public static Task PatchAsync(GameServer server, int currentClientVersion, bool cleanupTemp, CancellationToken ct = default)
     {
+        return PatchAsync(server, currentClientVersion, cleanupTemp, progress: null, ct: ct);
+    }
+
+    /// <summary>
+    /// 패치를 수행합니다. 상위 계층에서는 현재 버전만 전달하면 됩니다.
+    /// </summary>
+    public static Task PatchAsync(
+        GameServer server,
+        int currentClientVersion,
+        bool cleanupTemp,
+        IProgress<PatchProgress>? progress = null,
+        CancellationToken ct = default)
+    {
         // TODO: 고급 설정에서 불러오기
         int maxConcurrency = 2;
         int maxExtractRetryCount = 2;
@@ -95,6 +108,7 @@ public static class PatchHelper
             tempRoot: clientSettings.TempPath,
             maxConcurrency: maxConcurrency,
             maxExtractRetryCount: maxExtractRetryCount,
+            progress: progress,
             ct: ct,
             cleanupTemp: cleanupTemp);
     }

--- a/GersangStation.WinUI/Core/Patch/PatchPipeline.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchPipeline.cs
@@ -29,6 +29,32 @@ public static class PatchPipeline
             tempRoot,
             maxConcurrency,
             maxExtractRetryCount,
+            progress: null,
+            cleanupTemp: cleanupTemp);
+    }
+
+    /// <summary>
+    /// <see cref="CancellationToken"/>을 모르는 호출자를 위한 간편 오버로드입니다.
+    /// 내부적으로 <see cref="CancellationToken.None"/>을 사용합니다.
+    /// </summary>
+    public static Task RunPatchFromServerAsync(
+        int currentClientVersion,
+        GameServer server,
+        string installRoot,
+        string tempRoot,
+        int maxConcurrency,
+        int maxExtractRetryCount,
+        IProgress<PatchProgress>? progress,
+        bool cleanupTemp = true)
+    {
+        return RunPatchFromServerAsync(
+            currentClientVersion,
+            server,
+            installRoot,
+            tempRoot,
+            maxConcurrency,
+            maxExtractRetryCount,
+            progress,
             CancellationToken.None,
             cleanupTemp);
     }
@@ -47,6 +73,33 @@ public static class PatchPipeline
         CancellationToken ct,
         bool cleanupTemp = true)
     {
+        return RunPatchFromServerAsync(
+            currentClientVersion,
+            server,
+            installRoot,
+            tempRoot,
+            maxConcurrency,
+            maxExtractRetryCount,
+            progress: null,
+            ct: ct,
+            cleanupTemp: cleanupTemp);
+    }
+
+    /// <summary>
+    /// 서버 메타(vsn.dat.gsz + Client_info_File/{version})를 읽어
+    /// 다운로드/병합/압축해제 파이프라인을 실행한다.
+    /// </summary>
+    public static Task RunPatchFromServerAsync(
+        int currentClientVersion,
+        GameServer server,
+        string installRoot,
+        string tempRoot,
+        int maxConcurrency,
+        int maxExtractRetryCount,
+        IProgress<PatchProgress>? progress,
+        CancellationToken ct,
+        bool cleanupTemp = true)
+    {
         return RunPatchAsync(
             currentClientVersion: currentClientVersion,
             server: server,
@@ -54,6 +107,7 @@ public static class PatchPipeline
             tempRoot: tempRoot,
             maxConcurrency: maxConcurrency,
             maxExtractRetryCount: maxExtractRetryCount,
+            progress: progress,
             ct: ct,
             cleanupTemp: cleanupTemp);
     }
@@ -78,8 +132,66 @@ public static class PatchPipeline
             tempRoot,
             maxConcurrency,
             maxExtractRetryCount,
+            progress: null,
+            cleanupTemp: cleanupTemp);
+    }
+
+    /// <summary>
+    /// <see cref="CancellationToken"/>을 모르는 호출자를 위한 간편 오버로드입니다.
+    /// 내부적으로 <see cref="CancellationToken.None"/>을 사용합니다.
+    /// </summary>
+    public static Task RunPatchAsync(
+        int currentClientVersion,
+        GameServer server,
+        string installRoot,
+        string tempRoot,
+        int maxConcurrency,
+        int maxExtractRetryCount,
+        IProgress<PatchProgress>? progress,
+        bool cleanupTemp = true)
+    {
+        return RunPatchAsync(
+            currentClientVersion,
+            server,
+            installRoot,
+            tempRoot,
+            maxConcurrency,
+            maxExtractRetryCount,
+            progress,
             CancellationToken.None,
             cleanupTemp);
+    }
+
+    /// <summary>
+    /// 패치 파일 다운로드 + (버전 오름차순) 압축 해제 + 임시폴더 정리.
+    ///
+    /// <para>CancellationToken은 "중간에 멈추고 싶을 때" 전달하는 취소 신호입니다.</para>
+    /// <para>취소를 쓰지 않으면 간편 오버로드(토큰 없는 메서드)를 사용해도 됩니다.</para>
+    ///
+    /// 1) vsn.dat.gsz로 최신 버전 조회
+    /// 2) 현재+1..최신 버전의 Client_info_File 수집
+    /// 3) 이후 다운로드/압축해제 파이프라인 실행
+    /// </summary>
+    public static Task RunPatchAsync(
+        int currentClientVersion,
+        GameServer server,
+        string installRoot,
+        string tempRoot,
+        int maxConcurrency,
+        int maxExtractRetryCount,
+        CancellationToken ct,
+        bool cleanupTemp = true)
+    {
+        return RunPatchAsync(
+            currentClientVersion,
+            server,
+            installRoot,
+            tempRoot,
+            maxConcurrency,
+            maxExtractRetryCount,
+            progress: null,
+            ct: ct,
+            cleanupTemp: cleanupTemp);
     }
 
     /// <summary>
@@ -99,6 +211,7 @@ public static class PatchPipeline
         string tempRoot,
         int maxConcurrency,
         int maxExtractRetryCount,
+        IProgress<PatchProgress>? progress,
         CancellationToken ct,
         bool cleanupTemp = true)
     {
@@ -118,10 +231,16 @@ public static class PatchPipeline
             Timeout = TimeSpan.FromMinutes(5)
         };
 
+        progress?.Report(new PatchProgress(0, "최신 버전 정보를 확인하는 중..."));
+
         int latestServerVersion = await ResolveLatestServerVersionAsync(http, server, tempRoot, maxExtractRetryCount, ct).ConfigureAwait(false);
         if (latestServerVersion < currentClientVersion)
+        {
+            progress?.Report(new PatchProgress(100, "이미 최신 버전입니다."));
             return;
+        }
 
+        progress?.Report(new PatchProgress(5, "패치 파일 목록을 준비하는 중..."));
         var entriesByVersion = await DownloadEntriesByVersionAsync(http, currentClientVersion, latestServerVersion, server, ct).ConfigureAwait(false);
 
         try
@@ -132,17 +251,27 @@ public static class PatchPipeline
             // 3) 최신 우선 병합 + 5) 버전 오름차순 해제용 ExtractPlan 생성
             // -----------------------------------------------------------------
             var plan = PatchPlanBuilder.BuildExtractPlan(entriesByVersion);
+            int totalFileCount = plan.ByVersion.Values.Sum(files => files.Count);
+            int extractedFileCount = 0;
 
             ct.ThrowIfCancellationRequested();
 
             // -----------------------------------------------------------------
             // 4) 계획에 포함된 .gsz 다운로드 (병렬 OK)
             // -----------------------------------------------------------------
+            progress?.Report(new PatchProgress(10, "패치 파일을 다운로드하는 중..."));
             await PatchDownloaderStage.DownloadAllAsync(
                 plan,
                 tempRoot: tempRoot,
                 server: server,
                 maxConcurrency: maxConcurrency,
+                onFileDownloaded: (completed, total) =>
+                {
+                    double percent = total <= 0
+                        ? 70
+                        : 10 + (completed * 60.0 / total);
+                    progress?.Report(new PatchProgress(percent, $"패치 파일 다운로드 중... ({completed}/{total})"));
+                },
                 ct: ct);
 
             ct.ThrowIfCancellationRequested();
@@ -150,6 +279,7 @@ public static class PatchPipeline
             // -----------------------------------------------------------------
             // 5) 압축 해제: 반드시 "버전 오름차순"으로, 설치 경로에 덮어쓰기
             // -----------------------------------------------------------------
+            progress?.Report(new PatchProgress(70, "패치 파일 압축 해제를 시작합니다..."));
             foreach (var kv in plan.ByVersion) // 오름차순
             {
                 int version = kv.Key;
@@ -168,6 +298,12 @@ public static class PatchPipeline
                         maxExtractRetryCount: maxExtractRetryCount,
                         http: http,
                         ct: ct).ConfigureAwait(false);
+
+                    extractedFileCount++;
+                    double percent = totalFileCount <= 0
+                        ? 100
+                        : 70 + (extractedFileCount * 30.0 / totalFileCount);
+                    progress?.Report(new PatchProgress(percent, $"패치 적용 중... ({extractedFileCount}/{totalFileCount})"));
                 }
             }
 
@@ -176,6 +312,8 @@ public static class PatchPipeline
             // -----------------------------------------------------------------
             if (cleanupTemp)
                 TryDeleteDirectory(tempRoot);
+
+            progress?.Report(new PatchProgress(100, "패치가 완료되었습니다."));
         }
         catch (OperationCanceledException)
         {

--- a/GersangStation.WinUI/Core/Patch/PatchProgress.cs
+++ b/GersangStation.WinUI/Core/Patch/PatchProgress.cs
@@ -1,0 +1,6 @@
+namespace Core.Patch;
+
+public sealed record PatchProgress(
+    double Percentage,
+    string Message
+);

--- a/GersangStation.WinUI/GersangStation/Main/Setting/GamePatchSettingPage.xaml.cs
+++ b/GersangStation.WinUI/GersangStation/Main/Setting/GamePatchSettingPage.xaml.cs
@@ -228,8 +228,20 @@ public sealed partial class GamePatchSettingPage : Page, INotifyPropertyChanged,
             ProgressValue = 0;
             ProgressText = "패치를 준비하는 중...";
 
-            await RunDummyPatchAsync(_patchCts.Token);
+            var patchProgress = new Progress<PatchProgress>(p =>
+            {
+                ProgressValue = Math.Clamp(p.Percentage, 0, ProgressMaximum);
+                ProgressText = p.Message;
+            });
 
+            await PatchHelper.PatchAsync(
+                server: AppDataManager.SelectedServer,
+                currentClientVersion: _currentClientVersion,
+                cleanupTemp: ShouldDeleteTemp,
+                progress: patchProgress,
+                ct: _patchCts.Token);
+
+            ProgressValue = ProgressMaximum;
             ProgressText = "패치가 완료되었습니다.";
         }
         catch (OperationCanceledException)
@@ -251,20 +263,6 @@ public sealed partial class GamePatchSettingPage : Page, INotifyPropertyChanged,
             return;
 
         _patchCts?.Cancel();
-    }
-
-    // TODO: 삭제
-    private async Task RunDummyPatchAsync(CancellationToken cancellationToken)
-    {
-        for (int i = 1; i <= 100; i++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            ProgressValue = i;
-            ProgressText = $"패치 진행 중... {i}%";
-
-            await Task.Delay(30, cancellationToken);
-        }
     }
 
     private async void Button_Refresh_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- 기존 `PatchAsync`는 진행도를 상위 계층에 전달하지 않아 `GamePatchSettingPage`에서 더미 루프로 진행도를 표시하고 있었으므로 실제 패치 파이프라인의 진행도를 UI에 연결하기 위해 변경합니다.

### Description
- 진행 상태 전달용 `PatchProgress` record를 추가했습니다 (`Core.Patch.PatchProgress`).
- `PatchHelper.PatchAsync`와 `PatchPipeline.RunPatchAsync`/`RunPatchFromServerAsync`에 `IProgress<PatchProgress>? progress` 오버로드를 추가하고 기존 시그니처는 유지해 하위 호환성을 보장했습니다.
- `PatchPipeline`에 메타 조회, 목록 준비, 다운로드(10~70 영역), 압축 해제(70~100 영역), 완료 단계별로 `PatchProgress`를 보고하도록 구현했습니다.
- 병렬 다운로드 단계의 진행 산정을 위해 `PatchDownloaderStage.DownloadAllAsync`에 파일 단위 완료 콜백(`Action<int,int>? onFileDownloaded`)을 추가하고 중복 완료 보고를 방지하도록 보완했습니다.
- UI 쪽 `GamePatchSettingPage.Button_PatchStart_Click`에서 더미 루프를 제거하고 `Progress<PatchProgress>`를 전달하여 실제 `PatchHelper.PatchAsync`와 연동되게 변경했습니다.

### Testing
- 프로젝트 빌드 검증을 시도하기 위해 `dotnet build GersangStation.WinUI/Core/Core.csproj -v minimal`를 실행했으나 현재 환경에 `dotnet`이 없어(`command not found`) 빌드 검증을 완료하지 못했습니다.
- 변경 사항은 로컬에서 커밋되어 (5 files changed, 193 insertions, 18 deletions) 커밋이 생성되었습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9dcbaffc483219cd16e2c0ae3079f)